### PR TITLE
Allow for application/x-gzip to be accepted

### DIFF
--- a/src/components/addSubmission/StepSecond.vue
+++ b/src/components/addSubmission/StepSecond.vue
@@ -116,7 +116,7 @@ function savePackagesInStore() {
 }
 
 function checkValidity(file: File) {
-  return filesStore.checkValidity(file, 'application/gzip')
+  return filesStore.checkValidity(file, 'application/gzip') || filesStore.checkValidity(file, 'application/x-gzip')
 }
 
 onMounted(() => {


### PR DESCRIPTION
`application-gzip` and `application-xgzip` are equivalent. This MR allows the frontend to accept file types of `application-xgzip` as well for submission.

Closes https://github.com/openanalytics/RDepot-client/issues/1